### PR TITLE
enhance zbc::NewWorkflowInstance to handle a more general payload

### DIFF
--- a/zbc/client.go
+++ b/zbc/client.go
@@ -135,7 +135,7 @@ func NewTask(typeName, lockOwner string) *zbmsgpack.Task {
 }
 
 // NewWorkflowInstance will create new workflow instance.
-func NewWorkflowInstance(bpmnProcessID string, version int, payload map[string]interface{}) *zbmsgpack.WorkflowInstance {
+func NewWorkflowInstance(bpmnProcessID string, version int, payload ...interface{}) *zbmsgpack.WorkflowInstance {
 	b, err := msgpack.Marshal(payload)
 	if err != nil {
 		return nil


### PR DESCRIPTION
provide a more general api to create a new workflow instance e.g. to use custom structs as payload. 